### PR TITLE
Fix the typo in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Provided an iterable of 2-tuples in ``(symbol, weight)`` format, generate a Huff
 
 ::
 
-    >>> huffman.codebook([('A', 2), ('B', 4), ('C', 1), ('D', 1))
+    >>> huffman.codebook([('A', 2), ('B', 4), ('C', 1), ('D', 1))]
     {'A': '10', 'B': '0', 'C': '110', 'D': '111'}
 
 If you have an iterable of symbols, the ``collections.Counter`` is a handy way to tally them up.

--- a/huffman/huffman.py
+++ b/huffman/huffman.py
@@ -60,7 +60,7 @@ def codebook(symbolweights):
     Huffman codebook, returned as a dictionary in {symbol: code} format.
 
     Examples:
-    >>> huffman.codebook([('A', 2), ('B', 4), ('C', 1), ('D', 1))
+    >>> huffman.codebook([('A', 2), ('B', 4), ('C', 1), ('D', 1)])
     {'A': '10', 'B': '0', 'C': '110', 'D': '111'}
 
     >>> huffman.codebook(collections.Counter('man the stand banana man').items())


### PR DESCRIPTION
As the #1 pointed out, the typo is fixed.